### PR TITLE
KP-7380 Add regular Metax sync

### DIFF
--- a/metasharePouta.yml
+++ b/metasharePouta.yml
@@ -73,3 +73,5 @@
       tags: syncmeta
     - role: firewall
       tags: firewall
+    - role: metax_bridge
+      tags: metax_bridge

--- a/roles/metax_bridge/tasks/main.yml
+++ b/roles/metax_bridge/tasks/main.yml
@@ -27,6 +27,13 @@
 
 - name: Create virtualenv for Metax bridge
   ansible.builtin.pip:
-    virtualenv: "{{ bridge_installation_dir }}/.venv"
+    virtualenv: "{{ bridge_virtualenv_dir }}"
     virtualenv_command: python3.6 -m virtualenv
     requirements: "{{ bridge_installation_dir }}/requirements.txt"
+
+
+- name: Setup cronjob for regular harvesting
+  ansible.builtin.template:
+    dest: /etc/cron.daily/send_data_to_metax.cron
+    src: send_data_to_metax.cron.j2
+    mode: 0744

--- a/roles/metax_bridge/tasks/main.yml
+++ b/roles/metax_bridge/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+
+- name: Clone Metashare-Metax bridge repo
+  ansible.builtin.git:
+    repo: https://github.com/CSCfi/Kielipankki-Metax-bridge.git
+    dest: "{{ bridge_installation_dir }}"
+    version: "{{ bridge_version }}"
+
+- name: Create log directory
+  ansible.builtin.file:
+    path: "{{ bridge_log_dir }}"
+    state: directory
+    recurse: true
+
+- name: Configure the bridge
+  ansible.builtin.template:
+    dest: "{{ bridge_config_file }}"
+    src: config.yml.j2
+
+- name: Install Python 3.6
+  ansible.builtin.yum:
+    name: "{{ item }}"
+    state: installed
+  loop:
+    - python3  # defaults to 3.6 on CentOS7, needs to be changed when updating
+    - python36-virtualenv
+
+- name: Create virtualenv for Metax bridge
+  ansible.builtin.pip:
+    virtualenv: "{{ bridge_installation_dir }}/.venv"
+    virtualenv_command: python3.6 -m virtualenv
+    requirements: "{{ bridge_installation_dir }}/requirements.txt"

--- a/roles/metax_bridge/templates/config.yml.j2
+++ b/roles/metax_bridge/templates/config.yml.j2
@@ -1,0 +1,7 @@
+---
+metax_api_token: {{ lookup('passwordstore', 'lb_passwords/metax/metax_v3_api_token') }}
+metax_base_url: https://metax.fd-rework.csc.fi/v3
+metax_catalog_id: urn:nbn:fi:att:data-catalog-kielipankki
+
+harvester_log_file: {{ harvester_log_file }}
+metax_api_log_file: {{ metax_api_log_file }}

--- a/roles/metax_bridge/templates/send_data_to_metax.cron.j2
+++ b/roles/metax_bridge/templates/send_data_to_metax.cron.j2
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source {{ bridge_virtualenv_dir }}/bin/activate
+python {{ bridge_installation_dir }}/metadata_harvester_cli.py {{ bridge_config_file }}

--- a/roles/metax_bridge/vars/main.yml
+++ b/roles/metax_bridge/vars/main.yml
@@ -3,6 +3,7 @@ bridge_version: main
 
 bridge_installation_dir: /opt/metax-bridge
 bridge_config_file: "{{ bridge_installation_dir }}/config/config.yml"
+bridge_virtualenv_dir: "{{ bridge_installation_dir }}/.venv"
 
 bridge_log_dir: /var/log/metax_bridge
 harvester_log_file: "{{ bridge_log_dir }}/harvester.log"

--- a/roles/metax_bridge/vars/main.yml
+++ b/roles/metax_bridge/vars/main.yml
@@ -1,0 +1,9 @@
+---
+bridge_version: main
+
+bridge_installation_dir: /opt/metax-bridge
+bridge_config_file: "{{ bridge_installation_dir }}/config/config.yml"
+
+bridge_log_dir: /var/log/metax_bridge
+harvester_log_file: "{{ bridge_log_dir }}/harvester.log"
+metax_api_log_file: "{{ bridge_log_dir }}/metax_api_log_file.log"


### PR DESCRIPTION
Provision a cronjob for running the Metax sync.

Python 3.6 is the newest that is officially available for CentOS 7, so running on that. It's a bit risky business because our pipelines only test on 3.8, but the codebase is not likely to go through that much development in the near future, and CentOS 7 needs to be ditched fairly soon, so we likely don't have time to run to big problems.

The provisioned cronjob has run daily over the weekend, and the results seem promising: the names with conflicting languages that were fixed on Friday now appear in the Metax testing environment as they should.

TODO:
- [x] merge https://github.com/CSCfi/Kielipankki-Metax-bridge/pull/20
- [x] merge https://github.com/CSCfi/Kielipankki-metashare-ansible/pull/1
- [x] decide on the schedule
- [x] rebase