### PR TITLE
KP-8499 Reduce solr log disk space needs

### DIFF
--- a/roles/solr/defaults/main.yml
+++ b/roles/solr/defaults/main.yml
@@ -2,5 +2,5 @@
 solr_home: /usr/local/
 solr_version: 4.5.1
 solr_url: "http://archive.apache.org/dist/lucene/solr/{{ solr_version }}/solr-{{ solr_version }}.tgz"
-solr_logrotate_keep: 4
-solr_logrotate_frequency: weekly
+solr_logrotate_keep: 28
+solr_logrotate_frequency: daily

--- a/roles/solr/templates/logrotate.j2
+++ b/roles/solr/templates/logrotate.j2
@@ -4,6 +4,7 @@
     missingok
     notifempty
     sharedscripts
+    compress
     delaycompress
     postrotate
         /bin/systemctl reload httpd.service > /dev/null 2>/dev/null || true


### PR DESCRIPTION
Solr can write a lot of log (>1GB on busy days). Previously our solr logs were not compressed at all, which caused excessive disk space usage, up to the point of the disk being completely full.

Now old logs are compressed, and rotation frequency was increased to daily to lower the peaks that come from accumulating two weeks of logs before rotating.